### PR TITLE
Resolve #4 - Adds inc/dec postfix operator rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ detekt-operator is a plugin for [detekt](https://github.com/arturbosch/detekt) t
     - [x] `a.unaryPlus()` -> `+a`
     - [x] `a.unaryMinus()` -> `-a`
     - [x] `a.not()` -> `!a`
-    - [ ] `a.inc()` -> `a++`
-    - [ ] `a.dec()` -> `a--`
+    - [x] `a.inc()` -> `a++`
+    - [x] `a.dec()` -> `a--`
 - [ ] Arithmetic Operators
     - [ ] `a.plus(b)` -> `a + b`
     - [ ] `a.minus(b)` -> `a - b`

--- a/src/main/kotlin/io/cole/matthew/detekt/operator/rules/PreferUnaryPostfixOverFunctionSyntax.kt
+++ b/src/main/kotlin/io/cole/matthew/detekt/operator/rules/PreferUnaryPostfixOverFunctionSyntax.kt
@@ -1,0 +1,33 @@
+package io.cole.matthew.detekt.operator.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Entity
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.util.OperatorNameConventions
+import org.jetbrains.kotlin.util.isValidOperator
+
+class PreferUnaryPostfixOverFunctionSyntax : PreferOperatorOverNamedFunctionSyntaxBase(
+    """
+        The unary postfix operators are referenced by their named function translation. 
+        This can be replaced by <value1>[(++)(--)].
+    """.trimIndent()
+) {
+    override fun visitCallExpression(expression: KtCallExpression) {
+        (expression.getResolvedCall(bindingContext)?.candidateDescriptor as? FunctionDescriptor)?.let { descriptor ->
+            if (descriptor.name != OperatorNameConventions.INC && descriptor.name != OperatorNameConventions.DEC) {
+                return
+            }
+
+            if (descriptor.isValidOperator()) {
+                report(CodeSmell(issue, Entity.from(expression), """
+                    The ${descriptor.fqNameOrNull()} method can be replaced with its unary postfix operator equivalent.
+                """.trimIndent()))
+            }
+        }
+
+        super.visitCallExpression(expression)
+    }
+}

--- a/src/test/kotlin/io/cole/matthew/detekt/operator/rules/PreferUnaryPostfixOverFunctionSyntaxTest.kt
+++ b/src/test/kotlin/io/cole/matthew/detekt/operator/rules/PreferUnaryPostfixOverFunctionSyntaxTest.kt
@@ -1,0 +1,79 @@
+package io.cole.matthew.detekt.operator.rules
+
+import com.squareup.kotlinpoet.FileSpec
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldMatch
+import org.junit.jupiter.api.Test
+
+internal class PreferUnaryPostfixOverFunctionSyntaxTest : DetektRuleTestBase("unaryPostfix") {
+    override val subject = PreferUnaryPostfixOverFunctionSyntax()
+
+    private fun buildCode(func: String, namedArg: String): FileSpec {
+        return super.buildCode("return %num:L.%func:L()", "func" to func, "num" to namedArg)
+    }
+
+    private fun buildCode(func: String, namedArg: Char): FileSpec {
+        return super.buildCode("return %num:L.%func:L()", "func" to func, "num" to namedArg)
+    }
+
+    @Test
+    fun `reports if inc is used on a number`() {
+        listOf(
+            buildCode("inc", 1.toString()),
+            buildCode("inc", "(-1)"),
+            buildCode("inc", (-1).toString()),
+            buildCode("inc", 1.toByte().toString()),
+            buildCode("inc", 1.toDouble().toString()),
+            buildCode("inc", 1.toFloat().toString()),
+            buildCode("inc", 1L.toString()),
+            buildCode("inc", 1.toShort().toString()),
+            buildCode("inc", 'c'),
+            buildCode("inc", "BigDecimal.ONE"),
+            buildCode("inc", "BigInteger.ONE")
+        ).flatMap {
+            compileAndLint(it.toString())
+        }.run {
+            this.shouldNotBeEmpty()
+            with(this.distinctBy(Finding::issue)) {
+                this shouldHaveSize 1
+                this.first().issue shouldBe subject.issue
+                this.forEach { it.messageOrDescription() shouldMatch Regex(
+                    "The kotlin[a-zA-Z.]+ method can be replaced with its unary postfix operator equivalent\\."
+                ) }
+            }
+        }
+    }
+
+    @Test
+    fun `reports if dec is used on a number`() {
+        listOf(
+            buildCode("dec", 1.toString()),
+            buildCode("dec", "(-1)"),
+            buildCode("dec", (-1).toString()),
+            buildCode("dec", 1.toByte().toString()),
+            buildCode("dec", 1.toDouble().toString()),
+            buildCode("dec", 1.toFloat().toString()),
+            buildCode("dec", 1L.toString()),
+            buildCode("dec", 1.toShort().toString()),
+            buildCode("dec", 'd'),
+            buildCode("dec", "BigDecimal.ONE"),
+            buildCode("dec", "BigInteger.ONE")
+        ).flatMap {
+            compileAndLint(it.toString())
+        }.run {
+            this.shouldNotBeEmpty()
+            with(this.distinctBy(Finding::issue)) {
+                this shouldHaveSize 1
+                this.first().issue shouldBe subject.issue
+                this.forEach {
+                    it.messageOrDescription() shouldMatch Regex(
+                        "The kotlin[a-zA-Z.]+ method can be replaced with its unary postfix operator equivalent\\."
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Only postfix operators are detected by this rule because the inc/dec named functions cannot be converted to prefix operators (i.e. `++i`)